### PR TITLE
Change how shuffle works

### DIFF
--- a/src/Modules/voice/leave.js
+++ b/src/Modules/voice/leave.js
@@ -23,13 +23,7 @@ module.exports = class LeaveCommand extends Command {
       return msg.reply("You must join to my voice channel");
     }
 
-    // delete queue
-    delete msg.guild.queue;
-    delete msg.guild.playedQueue;
-    msg.guild.autoplay = false;
-    msg.guild.loop = false;
-    // leave the channel
-    return await msg.member.voice.channel.leave();
+    return msg.member.voice.channel.leave();
   }
 
   async onBlock(msg, reason, data) {

--- a/src/Modules/voice/loadplaylist.js
+++ b/src/Modules/voice/loadplaylist.js
@@ -58,12 +58,11 @@ module.exports = class LoadPlaylistCommand extends Command {
           msg.guild.queue = playlist.videoList;
           msg.guild.indexQueue = 0;
           play(msg);
-          return msg.say(`Added playlist **${playlist.name}**.`);
-        }
-        const oldLength = msg.guild.queue.length;
-        msg.guild.queue.push(...playlist.videoList);
-        if (msg.guild.indexQueue >= oldLength) {
-          play(msg);
+        } else {
+          const oldLength = msg.guild.queue.length;
+          msg.guild.queue.push(...playlist.videoList);
+          if (msg.guild.queueTemp) msg.guild.queueTemp.push(...playlist.videoList);
+          if (msg.guild.indexQueue >= oldLength) play(msg);
         }
         return msg.say(`Added playlist **${playlist.name}**.`);
       } catch (err) {
@@ -96,12 +95,11 @@ module.exports = class LoadPlaylistCommand extends Command {
           msg.guild.queue = playlist.videoList;
           msg.guild.indexQueue = 0;
           play(msg);
-          return msg.say(`Added playlist **${playlist.name}**.`);
-        }
-        const oldLength = msg.guild.queue.length;
-        msg.guild.queue.push(...playlist.videoList);
-        if (msg.guild.indexQueue >= oldLength) {
-          play(msg);
+        } else {
+          const oldLength = msg.guild.queue.length;
+          msg.guild.queue.push(...playlist.videoList);
+          if (msg.guild.queueTemp) msg.guild.queueTemp.push(...playlist.videoList);
+          if (msg.guild.indexQueue >= oldLength) play(msg);
         }
         return msg.say(`Added playlist **${playlist.name}**.`);
       } catch (err) {

--- a/src/Modules/voice/loop.js
+++ b/src/Modules/voice/loop.js
@@ -31,7 +31,6 @@ module.exports = class LoopCommand extends Command {
     } else {
       msg.guild.loop = turnOn;
     }
-    msg.guild.shuffle = msg.guild.loop ? false : msg.guild.shuffle;
     const embed = {
       color: msg.guild.loop ? 0x11ff00 : 0xff1100,
       description: `Set \`loop\` to **${msg.guild.loop ? 'True' : 'False'}**`

--- a/src/Modules/voice/queue.js
+++ b/src/Modules/voice/queue.js
@@ -54,7 +54,7 @@ module.exports = class QueueCommand extends Command {
     }
 
     // send embed
-    const embedMsg = await msg.say({ embed: setEmbedQueueCmd(queue, index, page, msg, itemsPerPage) });
+    const embedMsg = await msg.say({ embed: setEmbedQueueCmd(msg.guild.queue, index, page, msg, itemsPerPage) });
 
     const emojiNeeded = ['⬅', '➡', '🇽'];
 
@@ -88,7 +88,7 @@ module.exports = class QueueCommand extends Command {
         }
       }
       if (collected.emoji.name === '➡' || collected.emoji.name === '⬅') {
-        return embedMsg.edit({ embed: setEmbedQueueCmd(queue, index, page, msg, itemsPerPage) });
+        return embedMsg.edit({ embed: setEmbedQueueCmd(msg.guild.queue, index, page, msg, itemsPerPage) });
       }
 
     });

--- a/src/Modules/voice/removeno.js
+++ b/src/Modules/voice/removeno.js
@@ -1,3 +1,4 @@
+const { oneLine } = require('common-tags');
 const { Command } = require('discord.js-commando');
 
 
@@ -9,6 +10,10 @@ module.exports = class RemoveNumberCommand extends Command {
       aliases: ['rmno'],
       memberName: 'removeno',
       description: 'Remove given number from queue list',
+      details: oneLine`
+        When you remove a track while in shuffle mode,
+        the original queue is not affected.
+      `,
       examples: ['removeno 5', 'rmno 2-5'],
       guildOnly: true,
       throttling: {

--- a/src/Modules/voice/shuffle.js
+++ b/src/Modules/voice/shuffle.js
@@ -1,3 +1,4 @@
+const { oneLine } = require('common-tags');
 const { Command } = require('discord.js-commando');
 
 module.exports = class ShuffleCommand extends Command {
@@ -6,32 +7,34 @@ module.exports = class ShuffleCommand extends Command {
       name: 'shuffle',
       group: 'voice',
       memberName: 'shuffle',
-      description: 'Randomize next playing track',
+      description: 'Shuffle current queue',
+      details: oneLine`
+        If set to true, the current queue will be randomized but original queue
+        still remain in the memory. Set to false to load the original queue.
+      `,
       examples: ['shuffle', 'shuffle true'],
       guildOnly: true,
       throttling: {
         usages: 2,
-        duration: 10,
+        duration: 30,
       },
-      args: [
-        {
-          key: 'turnOn',
-          type: 'boolean',
-          prompt: 'Argument must be true or false.',
-          default: ''
-        }
-      ]
     });
   }
 
   /** @param {import("discord.js-commando").CommandoMessage} msg */
-  async run(msg, { turnOn }) {
-    if (turnOn === '') {
-      msg.guild.shuffle = !msg.guild.shuffle;
-    } else {
-      msg.guild.shuffle = turnOn;
+  async run(msg) {
+    if (!msg.guild.queue || !msg.guild.queue.length) {
+      return msg.reply(`The queue is empty.`);
     }
-    msg.guild.loop = msg.guild.shuffle ? false : msg.guild.loop;
+    msg.guild.shuffle = !msg.guild.shuffle;
+    if (msg.guild.shuffle) {
+      msg.guild.loop = false;
+      msg.guild.queueTemp = msg.guild.queue.slice();
+      shuffleArray(msg.guild.queue);
+    } else {
+      msg.guild.queue = msg.guild.queueTemp.slice();
+      delete msg.guild.queueTemp;
+    }
     const embed = {
       color: msg.guild.shuffle ? 0x11ff00 : 0xff1100,
       description: `Set \`shuffle\` to **${msg.guild.shuffle ? 'True' : 'False'}**`
@@ -41,3 +44,16 @@ module.exports = class ShuffleCommand extends Command {
 
 
 };
+
+/**
+ * Shuffle array using Durstenfeld shuffle
+ * @see {@link https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array}
+ * @param {Array<any>} arr
+ */
+function shuffleArray(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}

--- a/src/library/helper/player.js
+++ b/src/library/helper/player.js
@@ -34,7 +34,10 @@ async function playStream(msg, seek = 0) {
         msg.channel.stopTyping(true);
         delete msg.guild.queue;
         delete msg.guild.indexQueue;
-        delete msg.guild.played;
+        delete msg.guild.queueTemp;
+        msg.guild.autoplay = false;
+        msg.guild.loop = false;
+        msg.guild.shuffle = false;
       });
     }
     if (seek) {
@@ -143,6 +146,7 @@ async function fetchAutoplay(msg) {
     isLive: related[randTrack].isLive,
   };
   msg.guild.queue.push(construction);
+  if (msg.guild.queueTemp) msg.guild.queueTemp.push(construction);
   return play(msg);
 }
 
@@ -256,10 +260,10 @@ function player(data = {}, msg, fromPlaylist = false) {
         .catch(e => e);
     }
     // if in the end of queue and the song is stopped then play the track
-    if (msg.guild.indexQueue >= oldLength) {
-      return play(msg);
-    }
+    if (msg.guild.indexQueue >= oldLength) play(msg);
   }
+  if (msg.guild.queueTemp) msg.guild.queueTemp.push(construction);
+
 }
 
 module.exports = {

--- a/src/library/helper/player.js
+++ b/src/library/helper/player.js
@@ -188,23 +188,6 @@ async function play(msg, options = {}) {
     return playStream(msg, seek);
   }
 
-  // shuffle
-  if (msg.guild.shuffle) {
-    if (!msg.guild.played) {
-      msg.guild.played = [];
-    }
-    if (msg.guild.played.length < queue.length) {
-      let randIndex = Math.floor(Math.random() * queue.length);
-      while (msg.guild.played.includes(randIndex)) {
-        randIndex = Math.floor(Math.random() * queue.length);
-      }
-      msg.guild.indexQueue = randIndex;
-      msg.guild.played.push(randIndex);
-    } else {
-      msg.guild.indexQueue = queue.length;
-    }
-  }
-
   // autoplay
   if (msg.guild.indexQueue === queue.length) {
     if (msg.guild.autoplay) {


### PR DESCRIPTION
Old shuffle was unstable and inefficient, so I changed the way it work at cost the rmno command is only affect the shuffled queue.
Basically when shuffle command is set to `True`, current queue is copied to another variable and shuffle the guild queue array using [Durstenfeld shuffle]( https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array). When set to `False` it will bring back the original queue.